### PR TITLE
Add repository agent instructions and architecture

### DIFF
--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -19,8 +19,12 @@ jobs:
           while IFS= read -r -d '' file; do
             found=1
             echo "Validating $file"
-            docker compose -f "$file" config --quiet
-          done < <(find apps stacks shared profiles -name "compose.yaml" -print0)
+            docker compose -f "$file" config --quiet || exit 1
+          done < <(
+            for root in apps stacks shared profiles; do
+              [ -d "$root" ] && find "$root" -name "compose.yaml" -print0
+            done
+          )
 
           if [ "$found" -eq 0 ]; then
             echo "No compose.yaml files found yet. Skipping validation."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,11 @@
-# AGENTS.md
+# Role and Objective
+Provide accurate, safe, and reviewable contributions for Docker Atlas, a catalogue-first repository for reusable Docker Compose apps, stacks, standards, and deployment patterns.
 
-These instructions are for AI coding agents and automation assistants working in Docker Atlas.
+# Context
+These instructions apply to AI coding agents and automation assistants working in Docker Atlas.
 
-## Project purpose
-
-Docker Atlas is a catalogue-first repository for reusable Docker Compose apps, stacks, standards, and deployment patterns.
-
-The project prioritises:
-
+## Project Purpose
+Docker Atlas prioritises:
 - reusable Compose entries
 - clear deployment documentation
 - safe defaults
@@ -15,8 +13,7 @@ The project prioritises:
 - portable paths and environment variables
 - explicit security, backup, restore, and update notes
 
-## Repository structure
-
+## Repository Structure
 - `apps/` — single application entries
 - `stacks/` — grouped multi-service deployment patterns
 - `shared/` — shared Compose fragments, common networks, and reusable patterns
@@ -26,16 +23,14 @@ The project prioritises:
 - `docs/` — supporting documentation and design notes
 - `.github/` — issue templates, pull request template, and validation workflows
 
-## Core standards
-
+## Core Standards
 Follow these repository standards before adding or changing entries:
-
 - `standards/compose-style-guide.md`
 - `standards/security-checklist.md`
 - `docs/catalogue-standard.md`
 
-## Non-negotiables
-
+# Instructions
+## Non-Negotiables
 - Use `compose.yaml` as the canonical Compose filename.
 - Do not add the obsolete top-level `version` property.
 - Do not commit real secrets, production `.env` files, tokens, passwords, private URLs, or tunnel credentials.
@@ -45,8 +40,7 @@ Follow these repository standards before adding or changing entries:
 - Prefer safe, portable defaults over host-specific convenience.
 - Use small, reviewable changes rather than broad refactors.
 
-## Required entry files
-
+## Required Entry Files
 Each app or stack entry should include:
 
 ```text
@@ -58,20 +52,65 @@ README.md
 
 Use `templates/metadata.yaml` and `templates/README.template.md` as the starting point.
 
-## App vs stack boundaries
+## App vs. Stack Boundaries
+- Use `apps/` for one deployable app, even if it has optional integrations.
+- Use `stacks/` when multiple services form one operational pattern, such as:
+  - n8n + Postgres + Redis
+  - Jellyfin or Plex + Sonarr + Radarr + Prowlarr + qBittorrent
+  - Open WebUI + optional n8n + optional local model endpoint
+- If unsure, start with an app issue and propose a stack separately.
 
-Use `apps/` for one deployable app, even if it has optional integrations.
+## Security Expectations
+Treat these as high-risk and document them clearly when required:
+- Docker socket mounts
+- `privileged: true`
+- `network_mode: host`
+- public admin web UIs
+- default credentials
+- persistent sensitive data
+- tunnel or reverse proxy exposure
+- hardware/device mounts
 
-Use `stacks/` when multiple services form one operational pattern, such as:
+Avoid risky permissions by default. If an upstream image requires them, explain why in both `README.md` and `metadata.yaml`.
 
-- n8n + Postgres + Redis
-- Jellyfin or Plex + Sonarr + Radarr + Prowlarr + qBittorrent
-- Open WebUI + optional n8n + optional local model endpoint
+## Documentation Expectations
+Every entry `README.md` should explain:
+- what the app or stack does
+- what services are included
+- required ports
+- required volumes and paths
+- environment variables
+- first-run setup
+- backup and restore
+- update steps
+- security notes
+- reverse proxy assumptions, where relevant
 
-If unsure, start with an app issue and propose a stack separately.
+## Pull Request Expectations
+Every pull request should:
+- link the relevant issue
+- keep the change focused
+- explain any security or deployment risk
+- include validation evidence, or state why validation was not run
+- update standards or templates when the change introduces a new pattern
 
-## Compose validation
+## Change Style
+Prefer:
+- explicit defaults
+- clear comments where needed
+- portable environment variables such as `TZ` and `DATA_ROOT`
+- predictable folder names in lowercase kebab-case
+- additive changes that do not break existing entries
 
+Avoid:
+- broad reorganisation without an issue
+- unreviewed host-specific assumptions
+- unexplained privileged access
+- hidden behaviour in scripts
+- committing generated files unless the repo standard requires them
+
+# Planning and Verification
+## Compose Validation
 Validate changed Compose files with:
 
 ```bash
@@ -89,68 +128,22 @@ done
 
 If validation cannot be run, state that clearly in the pull request notes.
 
-## Security expectations
+# Output Format
+- Use Markdown only where semantically appropriate, such as lists, code fences, and tables.
+- Format file, directory, function, and class names in backticks.
+- Preserve exact filenames and paths when referencing repository content.
 
-Treat these as high-risk and document them clearly when required:
+# Verbosity
+- Default to concise summaries.
+- For code, use high verbosity with readable names, comments, and straightforward control flow.
 
-- Docker socket mounts
-- `privileged: true`
-- `network_mode: host`
-- public admin web UIs
-- default credentials
-- persistent sensitive data
-- tunnel or reverse proxy exposure
-- hardware/device mounts
+# Persistence
+- Continue until the user’s query is fully resolved.
+- Do not stop on uncertainty; choose the most reasonable path and document assumptions at the end when needed.
+- End only when success criteria are met.
 
-Avoid risky permissions by default. If an upstream image requires them, explain why in both `README.md` and `metadata.yaml`.
-
-## Documentation expectations
-
-Every entry README should explain:
-
-- what the app or stack does
-- what services are included
-- required ports
-- required volumes and paths
-- environment variables
-- first-run setup
-- backup and restore
-- update steps
-- security notes
-- reverse proxy assumptions, where relevant
-
-## Pull request expectations
-
-Every pull request should:
-
-- link the relevant issue
-- keep the change focused
-- explain any security or deployment risk
-- include validation evidence, or state why validation was not run
-- update standards or templates when the change introduces a new pattern
-
-## Change style
-
-Prefer:
-
-- explicit defaults
-- clear comments where needed
-- portable environment variables such as `TZ` and `DATA_ROOT`
-- predictable folder names in lowercase kebab-case
-- additive changes that do not break existing entries
-
-Avoid:
-
-- broad reorganisation without an issue
-- unreviewed host-specific assumptions
-- unexplained privileged access
-- hidden behaviour in scripts
-- committing generated files unless the repo standard requires them
-
-## When to stop and ask
-
+# Stop Conditions
 Stop and request review before continuing when a change would:
-
 - alter the repository structure
 - change the metadata schema
 - introduce a new security-sensitive pattern

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,158 @@
+# AGENTS.md
+
+These instructions are for AI coding agents and automation assistants working in Docker Atlas.
+
+## Project purpose
+
+Docker Atlas is a catalogue-first repository for reusable Docker Compose apps, stacks, standards, and deployment patterns.
+
+The project prioritises:
+
+- reusable Compose entries
+- clear deployment documentation
+- safe defaults
+- reviewable changes
+- portable paths and environment variables
+- explicit security, backup, restore, and update notes
+
+## Repository structure
+
+- `apps/` — single application entries
+- `stacks/` — grouped multi-service deployment patterns
+- `shared/` — shared Compose fragments, common networks, and reusable patterns
+- `profiles/` — host-specific or environment-specific overrides
+- `templates/` — reusable metadata and README templates
+- `standards/` — style, security, and catalogue rules
+- `docs/` — supporting documentation and design notes
+- `.github/` — issue templates, pull request template, and validation workflows
+
+## Core standards
+
+Follow these repository standards before adding or changing entries:
+
+- `standards/compose-style-guide.md`
+- `standards/security-checklist.md`
+- `docs/catalogue-standard.md`
+
+## Non-negotiables
+
+- Use `compose.yaml` as the canonical Compose filename.
+- Do not add the obsolete top-level `version` property.
+- Do not commit real secrets, production `.env` files, tokens, passwords, private URLs, or tunnel credentials.
+- Keep single app entries in `apps/`.
+- Keep grouped deployment patterns in `stacks/`.
+- Document ports, volumes, networks, configuration, backup, restore, update, and security risks.
+- Prefer safe, portable defaults over host-specific convenience.
+- Use small, reviewable changes rather than broad refactors.
+
+## Required entry files
+
+Each app or stack entry should include:
+
+```text
+compose.yaml
+.env.example
+metadata.yaml
+README.md
+```
+
+Use `templates/metadata.yaml` and `templates/README.template.md` as the starting point.
+
+## App vs stack boundaries
+
+Use `apps/` for one deployable app, even if it has optional integrations.
+
+Use `stacks/` when multiple services form one operational pattern, such as:
+
+- n8n + Postgres + Redis
+- Jellyfin or Plex + Sonarr + Radarr + Prowlarr + qBittorrent
+- Open WebUI + optional n8n + optional local model endpoint
+
+If unsure, start with an app issue and propose a stack separately.
+
+## Compose validation
+
+Validate changed Compose files with:
+
+```bash
+docker compose -f path/to/compose.yaml config --quiet
+```
+
+To validate every Compose file in the repository:
+
+```bash
+find apps stacks shared profiles -name "compose.yaml" -print0 | while IFS= read -r -d '' file; do
+  echo "Validating $file"
+  docker compose -f "$file" config --quiet
+done
+```
+
+If validation cannot be run, state that clearly in the pull request notes.
+
+## Security expectations
+
+Treat these as high-risk and document them clearly when required:
+
+- Docker socket mounts
+- `privileged: true`
+- `network_mode: host`
+- public admin web UIs
+- default credentials
+- persistent sensitive data
+- tunnel or reverse proxy exposure
+- hardware/device mounts
+
+Avoid risky permissions by default. If an upstream image requires them, explain why in both `README.md` and `metadata.yaml`.
+
+## Documentation expectations
+
+Every entry README should explain:
+
+- what the app or stack does
+- what services are included
+- required ports
+- required volumes and paths
+- environment variables
+- first-run setup
+- backup and restore
+- update steps
+- security notes
+- reverse proxy assumptions, where relevant
+
+## Pull request expectations
+
+Every pull request should:
+
+- link the relevant issue
+- keep the change focused
+- explain any security or deployment risk
+- include validation evidence, or state why validation was not run
+- update standards or templates when the change introduces a new pattern
+
+## Change style
+
+Prefer:
+
+- explicit defaults
+- clear comments where needed
+- portable environment variables such as `TZ` and `DATA_ROOT`
+- predictable folder names in lowercase kebab-case
+- additive changes that do not break existing entries
+
+Avoid:
+
+- broad reorganisation without an issue
+- unreviewed host-specific assumptions
+- unexplained privileged access
+- hidden behaviour in scripts
+- committing generated files unless the repo standard requires them
+
+## When to stop and ask
+
+Stop and request review before continuing when a change would:
+
+- alter the repository structure
+- change the metadata schema
+- introduce a new security-sensitive pattern
+- require public exposure of an admin service
+- remove or weaken existing validation rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,12 @@
-# Role and Objective
+# Docker Atlas Agent Instructions
+
+## Role and Objective
 Provide accurate, safe, and reviewable contributions for Docker Atlas, a catalogue-first repository for reusable Docker Compose apps, stacks, standards, and deployment patterns.
 
-# Context
+## Context
 These instructions apply to AI coding agents and automation assistants working in Docker Atlas.
 
-## Project Purpose
+### Project Purpose
 Docker Atlas prioritises:
 - reusable Compose entries
 - clear deployment documentation
@@ -13,17 +15,17 @@ Docker Atlas prioritises:
 - portable paths and environment variables
 - explicit security, backup, restore, and update notes
 
-## Repository Structure
-Use [ARCHITECTURE.md](ARCHITECTURE.md#repository-model) as the source of truth for the repository model. In short, `apps/` contains single app entries, `stacks/` contains grouped deployment patterns, `shared/` contains reusable Compose fragments, `profiles/` contains host-specific variants, and `templates/`, `standards/`, and `docs/` define reusable guidance.
+### Repository Structure
+Use [ARCHITECTURE.md](ARCHITECTURE.md#repository-model) as the source of truth for the repository model. In short, `apps/` contains single app entries, `stacks/` contains grouped deployment patterns, `shared/` contains reusable Compose fragments, `profiles/` contains host-specific variants, and `templates/`, `standards/`, and `docs/` define reusable guidance. Some catalogue directories may be absent in a fresh checkout until the first matching entry or profile is added.
 
-## Core Standards
+### Core Standards
 Follow these repository standards before adding or changing entries:
 - [Compose Style Guide](standards/compose-style-guide.md)
 - [Security Checklist](standards/security-checklist.md)
 - [Catalogue Standard](docs/catalogue-standard.md)
 
-# Instructions
-## Non-Negotiables
+## Instructions
+### Non-Negotiables
 - Use `compose.yaml` as the canonical Compose filename.
 - Do not add the obsolete top-level `version` property.
 - Set a clear top-level Compose [`name`](standards/compose-style-guide.md#project-name) value for each Compose entry.
@@ -34,7 +36,7 @@ Follow these repository standards before adding or changing entries:
 - Prefer safe, portable defaults over host-specific convenience.
 - Use small, reviewable changes rather than broad refactors.
 
-## Required Entry Files
+### Required Entry Files
 Each app or stack entry should include:
 
 ```text
@@ -47,18 +49,18 @@ README.md
 Use [templates/metadata.yaml](templates/metadata.yaml) and [templates/README.template.md](templates/README.template.md) as the starting point.
 See [Catalogue Standard: Required files](docs/catalogue-standard.md#required-files) for the role of each file.
 
-## App vs. Stack Boundaries
+### App vs. Stack Boundaries
 - Use `apps/` for one deployable app, even if it has optional integrations; see [Apps](ARCHITECTURE.md#apps).
 - Use `stacks/` when multiple services form one operational pattern; see [Stacks](ARCHITECTURE.md#stacks).
 - If unsure, start with an app issue and propose a stack separately.
 
-## Security Expectations
+### Security Expectations
 Use the [Security Checklist](standards/security-checklist.md) and [Architecture security model](ARCHITECTURE.md#security-model) as the source of truth for risky patterns. Avoid risky permissions by default. If an upstream image requires them, explain why in both `README.md` and `metadata.yaml`.
 
-## Documentation Expectations
+### Documentation Expectations
 Every entry `README.md` should follow [templates/README.template.md](templates/README.template.md) and the [Catalogue Standard review expectations](docs/catalogue-standard.md#review-expectations), including deployment, maintenance, backup, restore, update, and security notes.
 
-## Pull Request Expectations
+### Pull Request Expectations
 Every pull request should:
 - link the relevant issue
 - keep the change focused
@@ -66,7 +68,7 @@ Every pull request should:
 - include validation evidence, or state why validation was not run
 - update standards or templates when the change introduces a new pattern
 
-## Change Style
+### Change Style
 Prefer:
 - explicit defaults
 - clear comments where needed
@@ -81,8 +83,8 @@ Avoid:
 - hidden behaviour in scripts
 - committing generated files unless the repo standard requires them
 
-# Planning and Verification
-## Compose Validation
+## Planning and Verification
+### Compose Validation
 Validate changed Compose files with:
 
 ```bash
@@ -110,21 +112,21 @@ fi
 
 If validation cannot be run, state that clearly in the pull request notes.
 
-# Output Format
+## Output Format
 - Use Markdown only where semantically appropriate, such as lists, code fences, and tables.
 - Format file, directory, function, and class names in backticks.
 - Preserve exact filenames and paths when referencing repository content.
 
-# Verbosity
+## Verbosity
 - Default to concise summaries.
 - For code, use high verbosity with readable names, comments, and straightforward control flow.
 
-# Persistence
+## Persistence
 - Continue until the user’s query is fully resolved.
 - Do not stop on uncertainty; choose the most reasonable path and document assumptions at the end when needed.
 - End only when success criteria are met.
 
-# Stop Conditions
+## Stop Conditions
 Stop and request review before continuing when a change would:
 - alter the repository structure
 - change the metadata schema

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,25 +14,19 @@ Docker Atlas prioritises:
 - explicit security, backup, restore, and update notes
 
 ## Repository Structure
-- `apps/` — single application entries
-- `stacks/` — grouped multi-service deployment patterns
-- `shared/` — shared Compose fragments, common networks, and reusable patterns
-- `profiles/` — host-specific or environment-specific overrides
-- `templates/` — reusable metadata and README templates
-- `standards/` — style, security, and catalogue rules
-- `docs/` — supporting documentation and design notes
-- `.github/` — issue templates, pull request template, and validation workflows
+Use [ARCHITECTURE.md](ARCHITECTURE.md#repository-model) as the source of truth for the repository model. In short, `apps/` contains single app entries, `stacks/` contains grouped deployment patterns, `shared/` contains reusable Compose fragments, `profiles/` contains host-specific variants, and `templates/`, `standards/`, and `docs/` define reusable guidance.
 
 ## Core Standards
 Follow these repository standards before adding or changing entries:
-- `standards/compose-style-guide.md`
-- `standards/security-checklist.md`
-- `docs/catalogue-standard.md`
+- [Compose Style Guide](standards/compose-style-guide.md)
+- [Security Checklist](standards/security-checklist.md)
+- [Catalogue Standard](docs/catalogue-standard.md)
 
 # Instructions
 ## Non-Negotiables
 - Use `compose.yaml` as the canonical Compose filename.
 - Do not add the obsolete top-level `version` property.
+- Set a clear top-level Compose [`name`](standards/compose-style-guide.md#project-name) value for each Compose entry.
 - Do not commit real secrets, production `.env` files, tokens, passwords, private URLs, or tunnel credentials.
 - Keep single app entries in `apps/`.
 - Keep grouped deployment patterns in `stacks/`.
@@ -50,41 +44,19 @@ metadata.yaml
 README.md
 ```
 
-Use `templates/metadata.yaml` and `templates/README.template.md` as the starting point.
+Use [templates/metadata.yaml](templates/metadata.yaml) and [templates/README.template.md](templates/README.template.md) as the starting point.
+See [Catalogue Standard: Required files](docs/catalogue-standard.md#required-files) for the role of each file.
 
 ## App vs. Stack Boundaries
-- Use `apps/` for one deployable app, even if it has optional integrations.
-- Use `stacks/` when multiple services form one operational pattern, such as:
-  - n8n + Postgres + Redis
-  - Jellyfin or Plex + Sonarr + Radarr + Prowlarr + qBittorrent
-  - Open WebUI + optional n8n + optional local model endpoint
+- Use `apps/` for one deployable app, even if it has optional integrations; see [Apps](ARCHITECTURE.md#apps).
+- Use `stacks/` when multiple services form one operational pattern; see [Stacks](ARCHITECTURE.md#stacks).
 - If unsure, start with an app issue and propose a stack separately.
 
 ## Security Expectations
-Treat these as high-risk and document them clearly when required:
-- Docker socket mounts
-- `privileged: true`
-- `network_mode: host`
-- public admin web UIs
-- default credentials
-- persistent sensitive data
-- tunnel or reverse proxy exposure
-- hardware/device mounts
-
-Avoid risky permissions by default. If an upstream image requires them, explain why in both `README.md` and `metadata.yaml`.
+Use the [Security Checklist](standards/security-checklist.md) and [Architecture security model](ARCHITECTURE.md#security-model) as the source of truth for risky patterns. Avoid risky permissions by default. If an upstream image requires them, explain why in both `README.md` and `metadata.yaml`.
 
 ## Documentation Expectations
-Every entry `README.md` should explain:
-- what the app or stack does
-- what services are included
-- required ports
-- required volumes and paths
-- environment variables
-- first-run setup
-- backup and restore
-- update steps
-- security notes
-- reverse proxy assumptions, where relevant
+Every entry `README.md` should follow [templates/README.template.md](templates/README.template.md) and the [Catalogue Standard review expectations](docs/catalogue-standard.md#review-expectations), including deployment, maintenance, backup, restore, update, and security notes.
 
 ## Pull Request Expectations
 Every pull request should:
@@ -120,10 +92,20 @@ docker compose -f path/to/compose.yaml config --quiet
 To validate every Compose file in the repository:
 
 ```bash
-find apps stacks shared profiles -name "compose.yaml" -print0 | while IFS= read -r -d '' file; do
+found=0
+while IFS= read -r -d '' file; do
+  found=1
   echo "Validating $file"
-  docker compose -f "$file" config --quiet
-done
+  docker compose -f "$file" config --quiet || exit 1
+done < <(
+  for root in apps stacks shared profiles; do
+    [ -d "$root" ] && find "$root" -name "compose.yaml" -print0
+  done
+)
+
+if [ "$found" -eq 0 ]; then
+  echo "No compose.yaml files found yet. Skipping validation."
+fi
 ```
 
 If validation cannot be run, state that clearly in the pull request notes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ If validation cannot be run, state that clearly in the pull request notes.
 
 ## Persistence
 - Continue until the user’s query is fully resolved.
-- Do not stop on uncertainty; choose the most reasonable path and document assumptions at the end when needed.
+- When uncertainty is low-impact, choose the most reasonable path and document assumptions at the end. When uncertainty affects security, ops, data, public exposure, schema, or repository structure, ask for review before proceeding.
 - End only when success criteria are met.
 
 ## Stop Conditions

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,256 @@
+# Architecture
+
+Docker Atlas is a catalogue-first repository for reusable Docker Compose deployments.
+
+It is designed to make Compose entries easy to find, review, validate, deploy, back up, and evolve.
+
+## Goals
+
+Docker Atlas aims to:
+
+- provide reusable Docker Compose app and stack entries
+- keep catalogue entries consistent and reviewable
+- document deployment risks before use
+- make backup, restore, update, and security expectations visible
+- support future exports to tools such as Portainer, Dockge, CasaOS, or a static web catalogue
+
+## Non-goals
+
+Docker Atlas does not aim to be:
+
+- a one-click production installer
+- a replacement for upstream app documentation
+- a secret store
+- a guarantee that every entry is production-ready
+- a place for host-specific personal configuration unless clearly isolated in `profiles/`
+
+## Repository model
+
+```text
+Docker Atlas
+├── apps/        Single application entries
+├── stacks/      Multi-service deployment patterns
+├── shared/      Reusable Compose fragments and common patterns
+├── profiles/    Host or environment-specific overrides
+├── templates/   Metadata and README templates
+├── standards/   Style, security, and catalogue rules
+├── docs/        Supporting documentation
+└── .github/     Issue forms, PR template, and validation workflows
+```
+
+## Apps
+
+Apps are single deployable services.
+
+Example:
+
+```text
+apps/uptime-kuma/
+  compose.yaml
+  .env.example
+  metadata.yaml
+  README.md
+```
+
+Apps may document optional integrations, but they should not bundle unrelated services by default.
+
+## Stacks
+
+Stacks are grouped deployment patterns where multiple services belong together operationally.
+
+Example:
+
+```text
+stacks/media/
+  compose.yaml
+  .env.example
+  metadata.yaml
+  README.md
+```
+
+Good stack candidates include:
+
+- automation: n8n + Postgres + Redis
+- media: Jellyfin or Plex + Sonarr + Radarr + Prowlarr + qBittorrent
+- private AI: Open WebUI + optional n8n + optional local model endpoint
+
+## Shared components
+
+`shared/` is for reusable Compose fragments and common deployment patterns.
+
+Examples may include:
+
+- proxy networks
+- common environment blocks
+- healthcheck patterns
+- reusable monitoring sidecars
+
+Shared components should be documented because they may be included by multiple entries.
+
+## Profiles
+
+`profiles/` is for host-specific or environment-specific variants.
+
+Examples:
+
+- Synology-specific paths
+- GPU or hardware acceleration variants
+- reverse proxy variants
+- VPN-bound download profiles
+
+Profiles should keep host-specific assumptions out of the base app or stack entry.
+
+## Templates
+
+`templates/` contains reusable starting points for entries.
+
+Current template types:
+
+- `templates/metadata.yaml`
+- `templates/README.template.md`
+
+Templates define the expected shape for future catalogue entries.
+
+## Standards
+
+`standards/` and `docs/` define the operating rules for the catalogue.
+
+Important files:
+
+- `standards/compose-style-guide.md`
+- `standards/security-checklist.md`
+- `docs/catalogue-standard.md`
+
+These documents are the source of truth for style, security, and review expectations.
+
+## Entry lifecycle
+
+Catalogue entries should move through a simple lifecycle:
+
+```text
+issue → draft entry → validation → tested → recommended
+```
+
+Suggested status values in `metadata.yaml`:
+
+- `draft` — entry exists but has not been fully reviewed
+- `tested` — Compose validates and has been tested locally
+- `recommended` — reviewed and suitable for regular use
+- `deprecated` — retained for reference only
+
+## Required entry files
+
+Each app or stack entry should include:
+
+```text
+compose.yaml
+.env.example
+metadata.yaml
+README.md
+```
+
+### `compose.yaml`
+
+The runnable Compose definition.
+
+### `.env.example`
+
+Safe example configuration values and placeholders.
+
+### `metadata.yaml`
+
+Machine-readable catalogue data used for browsing, filtering, review, and future export.
+
+### `README.md`
+
+Human-readable deployment, maintenance, backup, restore, update, and security notes.
+
+## Validation model
+
+Every Compose file should pass:
+
+```bash
+docker compose -f path/to/compose.yaml config --quiet
+```
+
+The repository validation workflow scans these folders:
+
+```text
+apps/
+stacks/
+shared/
+profiles/
+```
+
+A Compose file should be valid before a PR is marked ready for review.
+
+## Security model
+
+Docker Atlas treats these as high-risk patterns:
+
+- Docker socket access
+- host networking
+- privileged mode
+- exposed admin web UIs
+- default credentials
+- persistent sensitive data
+- public tunnel or reverse proxy exposure
+- hardware or device mounts
+
+Risky patterns are allowed only when they are needed and clearly documented.
+
+## Backup and restore model
+
+Any stateful entry must document:
+
+- which volumes or paths store state
+- what should be backed up
+- how to stop the stack safely before backup or restore
+- restore order for multi-service stacks
+- any database-specific notes
+
+Backups should be treated as incomplete until restore steps are documented.
+
+## Naming model
+
+Use lowercase kebab-case for folders:
+
+```text
+apps/open-webui
+apps/cloudflare-tunnel
+stacks/private-ai
+stacks/media
+```
+
+Use clear top-level Compose project names where appropriate:
+
+```yaml
+name: open-webui
+```
+
+## Future extension points
+
+Docker Atlas may later add:
+
+- generated catalogue index files
+- JSON export
+- Portainer template export
+- Dockge import helpers
+- CasaOS package export
+- static web UI
+- compatibility matrix by architecture or host type
+- automated metadata linting
+
+These should build on the existing catalogue model rather than replacing it.
+
+## Footguns
+
+Watch for these common problems:
+
+- using `latest` tags for important stateful services without documenting the risk
+- exposing admin UIs directly to the internet
+- hiding required setup in undocumented environment variables
+- mixing host-specific paths into base entries
+- creating stacks where a single app entry would be clearer
+- creating app entries that secretly depend on unrelated bundled services
+- documenting backup paths without restore steps

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,6 +26,8 @@ Docker Atlas does not aim to be:
 
 ## Repository model
 
+This model describes the intended catalogue layout. In a fresh checkout, entry directories such as `apps/`, `stacks/`, `shared/`, and `profiles/` may be absent until the first matching entry or profile is added.
+
 ```text
 Docker Atlas
 ├── apps/        Single application entries
@@ -37,6 +39,8 @@ Docker Atlas
 ├── docs/        Supporting documentation
 └── .github/     Issue forms, PR template, and validation workflows
 ```
+
+<a id="apps"></a>
 
 ## Apps
 
@@ -53,6 +57,8 @@ apps/uptime-kuma/
 ```
 
 Apps may document optional integrations, but they should not bundle unrelated services by default.
+
+<a id="stacks"></a>
 
 ## Stacks
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -140,7 +140,7 @@ Suggested status values in `metadata.yaml`:
 
 ## Required entry files
 
-Each app or stack entry should include:
+Each app or stack entry should include the catalogue entry files defined in [Catalogue Standard: Required files](docs/catalogue-standard.md#required-files):
 
 ```text
 compose.yaml
@@ -149,21 +149,7 @@ metadata.yaml
 README.md
 ```
 
-### `compose.yaml`
-
-The runnable Compose definition.
-
-### `.env.example`
-
-Safe example configuration values and placeholders.
-
-### `metadata.yaml`
-
-Machine-readable catalogue data used for browsing, filtering, review, and future export.
-
-### `README.md`
-
-Human-readable deployment, maintenance, backup, restore, update, and security notes.
+Use [templates/metadata.yaml](templates/metadata.yaml) and [templates/README.template.md](templates/README.template.md) when creating new entries.
 
 ## Validation model
 
@@ -173,7 +159,7 @@ Every Compose file should pass:
 docker compose -f path/to/compose.yaml config --quiet
 ```
 
-The repository validation workflow scans these folders:
+The repository validation model applies to `compose.yaml` files under:
 
 ```text
 apps/
@@ -182,22 +168,11 @@ shared/
 profiles/
 ```
 
-A Compose file should be valid before a PR is marked ready for review.
+A Compose file should be valid before a PR is marked ready for review. Use [AGENTS.md](AGENTS.md#compose-validation) for local validation commands and the [Compose validation workflow](.github/workflows/validate-compose.yml) for CI behaviour.
 
 ## Security model
 
-Docker Atlas treats these as high-risk patterns:
-
-- Docker socket access
-- host networking
-- privileged mode
-- exposed admin web UIs
-- default credentials
-- persistent sensitive data
-- public tunnel or reverse proxy exposure
-- hardware or device mounts
-
-Risky patterns are allowed only when they are needed and clearly documented.
+Docker Atlas avoids risky permissions and public exposure by default. Risky patterns are allowed only when they are needed and clearly documented in the entry README and metadata; use the [Security Checklist](standards/security-checklist.md) for detailed review.
 
 ## Backup and restore model
 
@@ -222,7 +197,7 @@ stacks/private-ai
 stacks/media
 ```
 
-Use clear top-level Compose project names where appropriate:
+Set a clear top-level Compose `name` for each Compose entry, following [Compose Style Guide: Project name](standards/compose-style-guide.md#project-name):
 
 ```yaml
 name: open-webui


### PR DESCRIPTION
## Summary

- Add root-level `AGENTS.md` with repository-specific guidance for coding agents and automation assistants.
- Add root-level `ARCHITECTURE.md` describing the Docker Atlas catalogue model, lifecycle, validation model, and security model.

Closes #20

## Type of change

- [ ] New app entry
- [ ] New stack entry
- [x] Standards or documentation update
- [ ] Fix existing entry
- [ ] Tooling or validation update
- [ ] Issue or pull request template update

## Entry details

Not applicable — documentation-only change.

| Field | Value |
|---|---|
| Entry path | N/A |
| Category | documentation |
| Status | N/A |
| Internet exposure | N/A |
| Stateful | no |
| Docker socket required | no |
| Host networking required | no |
| Privileged mode required | no |

## Validation

- [ ] I ran `docker compose config --quiet` for every changed `compose.yaml`
- [x] I checked the Compose file does not include the obsolete top-level `version` property
- [x] I checked all required environment variables are documented
- [x] I checked no real `.env` files, secrets, tokens, passwords, or private URLs are committed

No Compose files were changed, so Compose validation was not required.

## Catalogue checklist

- [ ] Uses `compose.yaml`
- [ ] Includes `.env.example` where configuration is needed
- [ ] Includes `metadata.yaml`
- [x] Includes README deployment notes / documentation guidance
- [x] Documents ports
- [x] Documents volumes and backup requirements
- [x] Documents restore steps for stateful apps
- [x] Documents update steps
- [x] Documents security risks and internet exposure
- [x] Documents reverse proxy assumptions where relevant

## Security checklist

- [x] Docker socket access is avoided or clearly justified
- [x] Host networking is avoided or clearly justified
- [x] Privileged mode is avoided or clearly justified
- [x] Default credentials are changed or clearly flagged
- [x] Admin interfaces are not exposed directly without guidance

## Notes

This PR adds foundational guidance only. It does not add or modify catalogue entries.

## Summary by Sourcery

Add root-level documentation for Docker Atlas architecture and coding agent guidelines.

Documentation:
- Add ARCHITECTURE.md describing the Docker Atlas catalogue model, repository layout, lifecycle, validation, security, and future extensions.
- Add AGENTS.md with repository-specific standards and workflows for AI coding agents and automation assistants.