### PR TITLE
Add GitHub Actions project field sync automation

### DIFF
--- a/.github/workflows/sync-project-fields.yml
+++ b/.github/workflows/sync-project-fields.yml
@@ -1,0 +1,327 @@
+name: Sync project fields
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+      - reopened
+      - closed
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to sync. Leave blank to sync all open issues."
+        required: false
+        type: string
+      dry_run:
+        description: "Log planned updates without changing project fields."
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  sync-project-fields:
+    name: Sync issue metadata to project fields
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Sync project fields
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_SYNC_TOKEN || github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const dryRun = Boolean(${{ inputs.dry_run || false }});
+            const projectOwner = process.env.PROJECT_OWNER || owner;
+            const projectNumber = Number(process.env.PROJECT_NUMBER);
+
+            if (!projectNumber) {
+              core.setFailed('Missing repository variable DOCKER_ATLAS_PROJECT_NUMBER.');
+              return;
+            }
+
+            const normalise = (value) => String(value || '').trim().toLowerCase();
+            const hasLabel = (issue, labelName) => issue.labels.some((label) => normalise(label.name) === normalise(labelName));
+
+            const getLabels = (issue) => issue.labels.map((label) => normalise(label.name));
+
+            async function graphql(query, variables) {
+              return github.graphql(query, variables);
+            }
+
+            async function loadProject() {
+              const common = `
+                id
+                fields(first: 50) {
+                  nodes {
+                    ... on ProjectV2FieldCommon {
+                      id
+                      name
+                      dataType
+                    }
+                    ... on ProjectV2SingleSelectField {
+                      id
+                      name
+                      dataType
+                      options {
+                        id
+                        name
+                      }
+                    }
+                  }
+                }
+                items(first: 100) {
+                  nodes {
+                    id
+                    content {
+                      ... on Issue {
+                        id
+                        number
+                        repository {
+                          nameWithOwner
+                        }
+                      }
+                    }
+                  }
+                }
+              `;
+
+              const userQuery = `query($login: String!, $number: Int!) {
+                user(login: $login) {
+                  projectV2(number: $number) { ${common} }
+                }
+              }`;
+
+              const orgQuery = `query($login: String!, $number: Int!) {
+                organization(login: $login) {
+                  projectV2(number: $number) { ${common} }
+                }
+              }`;
+
+              const viewerQuery = `query($number: Int!) {
+                viewer {
+                  projectV2(number: $number) { ${common} }
+                }
+              }`;
+
+              const attempts = [
+                ['user', () => graphql(userQuery, { login: projectOwner, number: projectNumber })],
+                ['organization', () => graphql(orgQuery, { login: projectOwner, number: projectNumber })],
+                ['viewer', () => graphql(viewerQuery, { number: projectNumber })],
+              ];
+
+              for (const [source, run] of attempts) {
+                try {
+                  const result = await run();
+                  const project = result.user?.projectV2 || result.organization?.projectV2 || result.viewer?.projectV2;
+                  if (project) {
+                    core.info(`Loaded project from ${source}: ${projectOwner} #${projectNumber}`);
+                    return project;
+                  }
+                } catch (error) {
+                  core.info(`Project lookup via ${source} failed: ${error.message}`);
+                }
+              }
+
+              throw new Error(`Could not load project ${projectOwner} #${projectNumber}. Check PROJECT_SYNC_TOKEN permissions and repository variables.`);
+            }
+
+            function getField(project, fieldName) {
+              return project.fields.nodes.find((field) => field && normalise(field.name) === normalise(fieldName));
+            }
+
+            function getSelectOption(field, value) {
+              if (!field || !field.options) return undefined;
+              return field.options.find((option) => normalise(option.name) === normalise(value));
+            }
+
+            function findProjectItem(project, issue) {
+              const repoName = `${owner}/${repo}`.toLowerCase();
+              return project.items.nodes.find((item) => {
+                const content = item.content;
+                return content?.number === issue.number && normalise(content.repository?.nameWithOwner) === repoName;
+              });
+            }
+
+            async function setSingleSelect(project, item, fieldName, value) {
+              if (!value) return;
+
+              const field = getField(project, fieldName);
+              if (!field) {
+                core.warning(`Project field not found: ${fieldName}`);
+                return;
+              }
+
+              const option = getSelectOption(field, value);
+              if (!option) {
+                core.warning(`Project field option not found: ${fieldName} = ${value}`);
+                return;
+              }
+
+              core.info(`Set ${fieldName} = ${value}`);
+
+              if (dryRun) return;
+
+              await graphql(`mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $optionId }
+                }) {
+                  projectV2Item { id }
+                }
+              }`, {
+                projectId: project.id,
+                itemId: item.id,
+                fieldId: field.id,
+                optionId: option.id,
+              });
+            }
+
+            function mapEntryType(issue) {
+              const title = normalise(issue.title);
+              if (hasLabel(issue, 'app request') || title.startsWith('add app:')) return 'App';
+              if (hasLabel(issue, 'stack request') || title.startsWith('add stack:')) return 'Stack';
+              if (hasLabel(issue, 'documentation') || hasLabel(issue, 'standards')) return 'Docs';
+              if (hasLabel(issue, 'tooling')) return 'Tooling';
+              return undefined;
+            }
+
+            function mapStatus(issue) {
+              if (issue.state === 'closed') return 'Done';
+              if (hasLabel(issue, 'needs review')) return 'Review';
+              if (hasLabel(issue, 'blocked')) return 'Blocked';
+              return 'Triage';
+            }
+
+            function mapPriority(issue) {
+              for (const value of ['p0', 'p1', 'p2', 'p3']) {
+                if (hasLabel(issue, value)) return value.toUpperCase();
+              }
+              return undefined;
+            }
+
+            function mapEffort(issue) {
+              if (hasLabel(issue, 'effort: small')) return 'Small';
+              if (hasLabel(issue, 'effort: medium')) return 'Medium';
+              if (hasLabel(issue, 'effort: large')) return 'Large';
+              return undefined;
+            }
+
+            function mapArea(issue) {
+              const labelToArea = {
+                media: 'Media',
+                monitoring: 'Monitoring',
+                automation: 'Automation',
+                dns: 'DNS',
+                updates: 'Automation',
+                proxy: 'Proxy',
+                notifications: 'Notifications',
+                'remote access': 'Network',
+                'private ai': 'Private AI',
+                'home automation': 'Home Automation',
+                bookmarks: 'Bookmarks',
+                storage: 'Storage',
+                security: 'Security',
+                documentation: 'Docs',
+                standards: 'Docs',
+                tooling: 'Utility',
+              };
+
+              const labels = getLabels(issue);
+              for (const [label, area] of Object.entries(labelToArea)) {
+                if (labels.includes(label)) return area;
+              }
+              return undefined;
+            }
+
+            function mapRiskReview(issue) {
+              const orderedRiskLabels = [
+                ['risk: docker socket', 'Docker socket'],
+                ['risk: privileged', 'Security'],
+                ['risk: host network', 'Network'],
+                ['risk: public exposure', 'Public exposure'],
+                ['risk: secrets', 'Secrets'],
+                ['risk: network impact', 'Network'],
+                ['risk: hardware access', 'Hardware'],
+                ['risk: stateful', 'Storage'],
+              ];
+
+              for (const [label, value] of orderedRiskLabels) {
+                if (hasLabel(issue, label)) return value;
+              }
+              return 'None';
+            }
+
+            function mapImplementationWave(issue) {
+              const milestoneTitle = normalise(issue.milestone?.title);
+              if (!milestoneTitle) return undefined;
+              if (milestoneTitle.includes('foundation') || milestoneTitle.startsWith('m0')) return 'Foundation';
+              if (milestoneTitle.includes('mvp') || milestoneTitle.startsWith('m1')) return 'MVP';
+              if (milestoneTitle.includes('media core') || milestoneTitle.startsWith('m2')) return 'Media Core';
+              if (milestoneTitle.includes('media expansion') || milestoneTitle.startsWith('m3')) return 'Media Expansion';
+              if (milestoneTitle.includes('stack') || milestoneTitle.startsWith('m4')) return 'Stacks';
+              return 'Later';
+            }
+
+            async function listIssuesToSync() {
+              const requestedIssue = '${{ inputs.issue_number || '' }}'.trim();
+
+              if (context.payload.issue) {
+                return [context.payload.issue];
+              }
+
+              if (requestedIssue) {
+                const issueNumber = Number(requestedIssue);
+                const { data } = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+                return [data];
+              }
+
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100,
+              });
+
+              return issues.filter((issue) => !issue.pull_request);
+            }
+
+            async function syncIssue(project, issue) {
+              core.info(`Syncing #${issue.number}: ${issue.title}`);
+
+              const item = findProjectItem(project, issue);
+              if (!item) {
+                core.warning(`Issue #${issue.number} is not in project ${projectOwner} #${projectNumber}; skipping.`);
+                return;
+              }
+
+              await setSingleSelect(project, item, 'Entry type', mapEntryType(issue));
+              await setSingleSelect(project, item, 'Status', mapStatus(issue));
+              await setSingleSelect(project, item, 'Priority', mapPriority(issue));
+              await setSingleSelect(project, item, 'Effort', mapEffort(issue));
+              await setSingleSelect(project, item, 'Area', mapArea(issue));
+              await setSingleSelect(project, item, 'Risk review', mapRiskReview(issue));
+              await setSingleSelect(project, item, 'Implementation wave', mapImplementationWave(issue));
+            }
+
+            const project = await loadProject();
+            const issues = await listIssuesToSync();
+
+            core.info(`Dry run: ${dryRun}`);
+            core.info(`Issues to sync: ${issues.map((issue) => `#${issue.number}`).join(', ')}`);
+
+            for (const issue of issues) {
+              await syncIssue(project, issue);
+            }
+        env:
+          PROJECT_OWNER: ${{ vars.DOCKER_ATLAS_PROJECT_OWNER }}
+          PROJECT_NUMBER: ${{ vars.DOCKER_ATLAS_PROJECT_NUMBER }}

--- a/.github/workflows/sync-project-fields.yml
+++ b/.github/workflows/sync-project-fields.yml
@@ -7,6 +7,8 @@ on:
       - edited
       - labeled
       - unlabeled
+      - milestoned
+      - demilestoned
       - reopened
       - closed
   workflow_dispatch:
@@ -24,6 +26,7 @@ on:
 permissions:
   contents: read
   issues: read
+  repository-projects: write
 
 jobs:
   sync-project-fields:
@@ -38,7 +41,8 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const dryRun = Boolean(${{ inputs.dry_run || false }});
+            const dryRun = String(process.env.DISPATCH_DRY_RUN || 'false').trim().toLowerCase() === 'true';
+            const requestedIssue = String(process.env.DISPATCH_ISSUE_NUMBER || '').trim();
             const projectOwner = process.env.PROJECT_OWNER || owner;
             const projectNumber = Number(process.env.PROJECT_NUMBER);
 
@@ -77,7 +81,11 @@ jobs:
                     }
                   }
                 }
-                items(first: 100) {
+                items(first: 100, after: $itemsCursor) {
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
                   nodes {
                     id
                     content {
@@ -93,35 +101,40 @@ jobs:
                 }
               `;
 
-              const userQuery = `query($login: String!, $number: Int!) {
+              const userQuery = `query($login: String!, $number: Int!, $itemsCursor: String) {
                 user(login: $login) {
                   projectV2(number: $number) { ${common} }
                 }
               }`;
 
-              const orgQuery = `query($login: String!, $number: Int!) {
+              const orgQuery = `query($login: String!, $number: Int!, $itemsCursor: String) {
                 organization(login: $login) {
                   projectV2(number: $number) { ${common} }
                 }
               }`;
 
-              const viewerQuery = `query($number: Int!) {
-                viewer {
-                  projectV2(number: $number) { ${common} }
-                }
-              }`;
-
               const attempts = [
-                ['user', () => graphql(userQuery, { login: projectOwner, number: projectNumber })],
-                ['organization', () => graphql(orgQuery, { login: projectOwner, number: projectNumber })],
-                ['viewer', () => graphql(viewerQuery, { number: projectNumber })],
+                ['user', (itemsCursor) => graphql(userQuery, { login: projectOwner, number: projectNumber, itemsCursor })],
+                ['organization', (itemsCursor) => graphql(orgQuery, { login: projectOwner, number: projectNumber, itemsCursor })],
               ];
 
               for (const [source, run] of attempts) {
                 try {
-                  const result = await run();
-                  const project = result.user?.projectV2 || result.organization?.projectV2 || result.viewer?.projectV2;
+                  const result = await run(null);
+                  const project = result.user?.projectV2 || result.organization?.projectV2;
                   if (project) {
+                    const items = [...project.items.nodes];
+                    let pageInfo = project.items.pageInfo;
+
+                    while (pageInfo.hasNextPage) {
+                      const page = await run(pageInfo.endCursor);
+                      const nextProject = page.user?.projectV2 || page.organization?.projectV2;
+                      if (!nextProject) break;
+                      items.push(...nextProject.items.nodes);
+                      pageInfo = nextProject.items.pageInfo;
+                    }
+
+                    project.items.nodes = items;
                     core.info(`Loaded project from ${source}: ${projectOwner} #${projectNumber}`);
                     return project;
                   }
@@ -151,11 +164,30 @@ jobs:
             }
 
             async function setSingleSelect(project, item, fieldName, value) {
-              if (!value) return;
-
               const field = getField(project, fieldName);
               if (!field) {
                 core.warning(`Project field not found: ${fieldName}`);
+                return;
+              }
+
+              if (!value) {
+                core.info(`Clear ${fieldName}`);
+
+                if (dryRun) return;
+
+                await graphql(`mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!) {
+                  clearProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                  }) {
+                    projectV2Item { id }
+                  }
+                }`, {
+                  projectId: project.id,
+                  itemId: item.id,
+                  fieldId: field.id,
+                });
                 return;
               }
 
@@ -231,6 +263,7 @@ jobs:
                 bookmarks: 'Bookmarks',
                 storage: 'Storage',
                 security: 'Security',
+                docs: 'Docs',
                 documentation: 'Docs',
                 standards: 'Docs',
                 tooling: 'Utility',
@@ -273,14 +306,17 @@ jobs:
             }
 
             async function listIssuesToSync() {
-              const requestedIssue = '${{ inputs.issue_number || '' }}'.trim();
-
               if (context.payload.issue) {
                 return [context.payload.issue];
               }
 
               if (requestedIssue) {
                 const issueNumber = Number(requestedIssue);
+                if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+                  core.setFailed(`Invalid issue_number input: ${requestedIssue}. Use a positive integer.`);
+                  return [];
+                }
+
                 const { data } = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
                 return [data];
               }
@@ -323,5 +359,7 @@ jobs:
               await syncIssue(project, issue);
             }
         env:
+          DISPATCH_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
+          DISPATCH_ISSUE_NUMBER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.issue_number || '' }}
           PROJECT_OWNER: ${{ vars.DOCKER_ATLAS_PROJECT_OWNER }}
           PROJECT_NUMBER: ${{ vars.DOCKER_ATLAS_PROJECT_NUMBER }}

--- a/docs/project-field-sync.md
+++ b/docs/project-field-sync.md
@@ -1,0 +1,203 @@
+# Project field sync automation
+
+Docker Atlas uses a GitHub Project named `Docker Atlas Catalogue` to track catalogue work without overloading issues with labels.
+
+The workflow in `.github/workflows/sync-project-fields.yml` syncs issue labels, state, and milestones into Project fields.
+
+## Workflow
+
+```text
+.github/workflows/sync-project-fields.yml
+```
+
+## What it updates
+
+The workflow maps issue metadata into these Project fields:
+
+- `Entry type`
+- `Status`
+- `Priority`
+- `Effort`
+- `Area`
+- `Risk review`
+- `Implementation wave`
+
+It intentionally does not update checklist-style fields such as `Upstream verified` or `Compose validated`, because those should reflect implementation evidence.
+
+## Required repository variables
+
+Create these repository variables under:
+
+```text
+Settings → Secrets and variables → Actions → Variables
+```
+
+| Variable | Required | Example | Purpose |
+|---|---:|---|---|
+| `DOCKER_ATLAS_PROJECT_NUMBER` | Yes | `1` | The visible Project number from the Project URL. |
+| `DOCKER_ATLAS_PROJECT_OWNER` | No | `SmolSoftBoi` | Project owner. Defaults to the repository owner if omitted. |
+
+## Token configuration
+
+The workflow uses this token preference:
+
+1. `secrets.PROJECT_SYNC_TOKEN`, if present
+2. `GITHUB_TOKEN`, as a fallback
+
+For user-level Projects, `GITHUB_TOKEN` may not have enough access to update Project v2 fields.
+
+If the fallback token cannot access the Project, create a fine-grained personal access token and save it as:
+
+```text
+PROJECT_SYNC_TOKEN
+```
+
+Recommended token access:
+
+- access to the `SmolSoftBoi/docker-atlas` repository
+- read access to issues
+- write access to Projects
+
+Keep token permissions as narrow as GitHub allows.
+
+## Supported triggers
+
+The workflow runs when an issue is:
+
+- opened
+- edited
+- labelled
+- unlabelled
+- reopened
+- closed
+
+It can also be run manually with `workflow_dispatch`.
+
+## Manual sync
+
+Use manual dispatch from:
+
+```text
+Actions → Sync project fields → Run workflow
+```
+
+Inputs:
+
+| Input | Use |
+|---|---|
+| `issue_number` | Sync one issue. Leave blank to sync all open issues. |
+| `dry_run` | Log planned updates without changing Project fields. |
+
+Recommended first run:
+
+```text
+issue_number: blank
+dry_run: true
+```
+
+If the dry run looks correct, run again with:
+
+```text
+dry_run: false
+```
+
+## Label mappings
+
+### Entry type
+
+| Label or title | Value |
+|---|---|
+| `app request` or title starts `Add app:` | `App` |
+| `stack request` or title starts `Add stack:` | `Stack` |
+| `documentation` or `standards` | `Docs` |
+| `tooling` | `Tooling` |
+
+### Status
+
+| Condition | Value |
+|---|---|
+| closed issue | `Done` |
+| label `needs review` | `Review` |
+| label `blocked` | `Blocked` |
+| otherwise open issue | `Triage` |
+
+### Priority
+
+| Label | Value |
+|---|---|
+| `p0` | `P0` |
+| `p1` | `P1` |
+| `p2` | `P2` |
+| `p3` | `P3` |
+
+### Effort
+
+| Label | Value |
+|---|---|
+| `effort: small` | `Small` |
+| `effort: medium` | `Medium` |
+| `effort: large` | `Large` |
+
+### Area
+
+| Label | Value |
+|---|---|
+| `media` | `Media` |
+| `monitoring` | `Monitoring` |
+| `automation` | `Automation` |
+| `dns` | `DNS` |
+| `updates` | `Automation` |
+| `proxy` | `Proxy` |
+| `notifications` | `Notifications` |
+| `remote access` | `Network` |
+| `private ai` | `Private AI` |
+| `home automation` | `Home Automation` |
+| `bookmarks` | `Bookmarks` |
+| `storage` | `Storage` |
+| `security` | `Security` |
+| `documentation` or `standards` | `Docs` |
+| `tooling` | `Utility` |
+
+### Risk review
+
+If the Project field is single-select, the workflow chooses the first matching item in this order:
+
+| Label | Value |
+|---|---|
+| `risk: docker socket` | `Docker socket` |
+| `risk: privileged` | `Security` |
+| `risk: host network` | `Network` |
+| `risk: public exposure` | `Public exposure` |
+| `risk: secrets` | `Secrets` |
+| `risk: network impact` | `Network` |
+| `risk: hardware access` | `Hardware` |
+| `risk: stateful` | `Storage` |
+| no matching risk label | `None` |
+
+## Implementation wave mapping
+
+The workflow maps the issue milestone title into `Implementation wave`.
+
+| Milestone title contains | Value |
+|---|---|
+| `Foundation` or starts with `M0` | `Foundation` |
+| `MVP` or starts with `M1` | `MVP` |
+| `Media Core` or starts with `M2` | `Media Core` |
+| `Media Expansion` or starts with `M3` | `Media Expansion` |
+| `Stack` or starts with `M4` | `Stacks` |
+| anything else | `Later` |
+
+## Failure modes
+
+The workflow is designed to fail safely:
+
+- If the Project number is missing, it stops with a clear error.
+- If an issue is not in the Project, it logs a warning and skips it.
+- If a Project field or option is missing, it logs a warning and continues.
+- It does not print tokens or secret values.
+
+## Notes
+
+GitHub Projects field IDs are discovered dynamically from the Project field names, so field names and option names must match the documented values exactly.
+
+If field names are changed in GitHub, update the workflow and this document in the same pull request.

--- a/docs/project-field-sync.md
+++ b/docs/project-field-sync.md
@@ -66,8 +66,10 @@ The workflow runs when an issue is:
 
 - opened
 - edited
-- labelled
-- unlabelled
+- labeled
+- unlabeled
+- milestoned
+- demilestoned
 - reopened
 - closed
 
@@ -155,6 +157,7 @@ dry_run: false
 | `bookmarks` | `Bookmarks` |
 | `storage` | `Storage` |
 | `security` | `Security` |
+| `docs` | `Docs` |
 | `documentation` or `standards` | `Docs` |
 | `tooling` | `Utility` |
 
@@ -186,6 +189,8 @@ The workflow maps the issue milestone title into `Implementation wave`.
 | `Media Expansion` or starts with `M3` | `Media Expansion` |
 | `Stack` or starts with `M4` | `Stacks` |
 | anything else | `Later` |
+
+When a label or milestone no longer maps to an optional field value, the workflow clears the corresponding Project field instead of leaving stale metadata in place.
 
 ## Failure modes
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/sync-project-fields.yml` to sync issue labels/state/milestones into the `Docker Atlas Catalogue` GitHub Project fields.
- Add `docs/project-field-sync.md` documenting setup, required repository variables, token configuration, mappings, manual sync, and failure modes.

Closes #37

## Type of change

- [ ] New app entry
- [ ] New stack entry
- [ ] Standards or documentation update
- [ ] Fix existing entry
- [x] Tooling or validation update
- [ ] Issue or pull request template update

## Validation

- [x] No Compose files were changed
- [x] Workflow syntax was reviewed structurally
- [x] Documentation includes required setup steps
- [x] Documentation explains token and Project access caveats

## Configuration required after merge

Create these repository variables:

```text
DOCKER_ATLAS_PROJECT_NUMBER
DOCKER_ATLAS_PROJECT_OWNER
```

If `GITHUB_TOKEN` cannot update the user-level Project, create a fine-grained token and save it as:

```text
PROJECT_SYNC_TOKEN
```

## Notes

The workflow discovers Project field IDs dynamically by field name, so the GitHub Project field names and option names must match the docs exactly.

## Summary by Sourcery

Introduce automated synchronization of issue metadata into the Docker Atlas Catalogue GitHub Project fields and document its configuration and behavior.

New Features:
- Add a GitHub Actions workflow to sync issue labels, state, and milestones into Docker Atlas Project fields.
- Document the project field sync workflow, configuration, and label/milestone mappings for the Docker Atlas Catalogue project.